### PR TITLE
CI is love, CI is life

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+jobs:
+  include:
+    - name: "Ubuntu 18.04 | Clang"
+      dist: bionic
+      compiler: clang
+    - name: "Ubuntu 18.04 | GCC"
+      dist: bionic
+      compiler: gcc
+    - name: "Ubuntu 20.04 | Clang"
+      dist: focal
+      compiler: clang
+    - name: "Ubuntu 20.04 | GCC"
+      dist: focal
+      compiler: gcc
+
+script:
+- set -e  # If any step reports a problem consider the whole build a failure
+- ./build.sh
+- ./FlashMQBuildRelease/FlashMQ --version
+- set +e  # Prevent Travis internals from breaking our build, see https://github.com/travis-ci/travis-ci/issues/891

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # FlashMQ
+[![Build Status](https://travis-ci.com/quinox/FlashMQ.svg?branch=master)](https://travis-ci.com/quinox/FlashMQ)
+
 FlashMQ is a light-weight MQTT broker/server, designed to take good advantage of multi-CPU environments.
 
 Build with buid.sh.

--- a/mosquittoauthoptcompatwrap.h
+++ b/mosquittoauthoptcompatwrap.h
@@ -21,6 +21,7 @@ License along with FlashMQ. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 #include <unordered_map>
 #include <cstring>
+#include <string>
 
 /**
  * @brief The mosquitto_auth_opt struct is a resource managed class of auth options, compatible with passing as arguments to Mosquitto

--- a/utils.cpp
+++ b/utils.cpp
@@ -32,7 +32,7 @@ License along with FlashMQ. If not, see <https://www.gnu.org/licenses/>.
 #include "logger.h"
 #include "evpencodectxmanager.h"
 
-std::list<std::__cxx11::string> split(const std::string &input, const char sep, size_t max, bool keep_empty_parts)
+std::list<std::string> split(const std::string &input, const char sep, size_t max, bool keep_empty_parts)
 {
     std::list<std::string> list;
     size_t start = 0;


### PR DESCRIPTION
The CI tests 4 combinations: Clang+GCC on 20.04+18.04. The project doesn't compile on 16.04 so I left it out.

Two tweaks to the code were needed to get the compilation working on my dev server. 

Don't forget to update the badge URL in the `README.md` to point to your own repo (Gitlab can't do this for you yet, see [this issue](https://github.com/github/markup/issues/913)). 

Depending on your own Travis settings you might also have to enable CI for this repo, this can be done at https://travis-ci.com/account/repositories