### PR TITLE
Add dockerfile and build/run instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# build target, used for building the binary, providing shared libraries and could be used as a development env
+FROM debian:bullseye-slim as build
+
+# install build dependencies
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install g++ make cmake libssl-dev
+
+# create flashmq user and group for runtime image below
+RUN useradd --system --shell /bin/false --user-group --no-log-init flashmq
+
+WORKDIR /usr/src/app
+COPY . .
+RUN ./build.sh
+
+
+# from scratch image is empty
+FROM scratch as run
+
+# set the user/group to flashmq and copy the passwd/group files from build to make that work
+USER flashmq:flashmq
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+
+# copy in the shared libaries in use discovered using ldd on release binary
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libssl.so.1.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+
+# copy in the FlashMQ binary itself
+COPY --from=build /usr/src/app/FlashMQBuildRelease/FlashMQ /bin/FlashMQ
+
+EXPOSE 1883
+CMD ["/bin/FlashMQ"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 FlashMQ is a light-weight MQTT broker/server, designed to take good advantage of multi-CPU environments.
 
-Build with buid.sh.
+Build with build.sh.
 
 See [www.flashmq.org](https://www.flashmq.org)

--- a/README.md
+++ b/README.md
@@ -5,4 +5,15 @@ FlashMQ is a light-weight MQTT broker/server, designed to take good advantage of
 
 Build with build.sh.
 
+## Docker
+```
+# build flashmq docker image
+docker build . -t halfgaar/flashmq
+
+# run using docker
+docker run -p 1883:1883 halfgaar/flashmq
+
+# for development you can target the build stage to get an image you can use for development
+docker build . --target=build
+```
 See [www.flashmq.org](https://www.flashmq.org)


### PR DESCRIPTION
# PR contents
- Adds dockerfile with build and run stage
- Adds some instructions on how to docker build/run 
- Fixes typo in readme

# Key Dockerfile related points
- From scratch for the runtime image resulting in <10mb image size
- Dynamically linked libraries (using the normal build.sh script) but copying the used libraries to an empty (scratch) image
- Container will run with app specific user/group (not root)
- Uses current debian stable as builder image


Let me know if there are things you would like to see changed and I will update the PR!

After this a nice step would be to have CI build the image, publish it to a public docker registry. Then you can update the website/readme with a `docker run` one-liner so people can easily try this out.