### PR TITLE
Fix missing dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:bullseye-slim as build
 
 # install build dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install g++ make cmake libssl-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install g++ make cmake libssl-dev file
 
 # create flashmq user and group for runtime image below
 RUN useradd --system --shell /bin/false --user-group --no-log-init flashmq


### PR DESCRIPTION
While trying to build the Dockerfile, it CPack kindly informed me that `file` was not installed. So installed `file` in the Dockerfile.