### PR TITLE
Add a Dockerfile that supports buildx for amd64/arm64

### DIFF
--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,0 +1,46 @@
+# build target, used for building the binary, providing shared libraries and could be used as a development env
+FROM debian:bullseye-slim as build
+
+# install build dependencies
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install g++ make cmake libssl-dev file
+
+# create flashmq user and group for runtime image below
+RUN useradd --system --shell /bin/false --user-group --no-log-init flashmq
+
+WORKDIR /usr/src/app
+COPY . .
+RUN ./build.sh
+
+# convert docker buildx platform name to Debian platform name
+FROM scratch AS run-amd64
+ARG PLATFORM=x86_64
+ARG LD_LOCATION=/lib64/ld-linux-x86-64.so.2
+
+FROM scratch AS run-arm64
+ARG PLATFORM=aarch64
+ARG LD_LOCATION=/lib/ld-linux-aarch64.so.1
+
+# from scratch image is empty
+FROM run-$TARGETARCH AS run
+
+# set the user/group to flashmq and copy the passwd/group files from build to make that work
+USER flashmq:flashmq
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+
+# copy in the shared libaries in use discovered using ldd on release binary
+COPY --from=build /lib/${PLATFORM}-linux-gnu/libpthread.so.0 /lib/${PLATFORM}-linux-gnu/libpthread.so.0
+COPY --from=build /lib/${PLATFORM}-linux-gnu/libdl.so.2 /lib/${PLATFORM}-linux-gnu/libdl.so.2
+COPY --from=build /usr/lib/${PLATFORM}-linux-gnu/libssl.so.1.1 /usr/lib/${PLATFORM}-linux-gnu/libssl.so.1.1
+COPY --from=build /usr/lib/${PLATFORM}-linux-gnu/libcrypto.so.1.1 /usr/lib/${PLATFORM}-linux-gnu/libcrypto.so.1.1
+COPY --from=build /usr/lib/${PLATFORM}-linux-gnu/libstdc++.so.6 /usr/lib/${PLATFORM}-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/${PLATFORM}-linux-gnu/libgcc_s.so.1 /lib/${PLATFORM}-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/${PLATFORM}-linux-gnu/libc.so.6 /lib/${PLATFORM}-linux-gnu/libc.so.6
+COPY --from=build ${LD_LOCATION} ${LD_LOCATION}
+COPY --from=build /lib/${PLATFORM}-linux-gnu/libm.so.6 /lib/${PLATFORM}-linux-gnu/libm.so.6
+
+# copy in the FlashMQ binary itself
+COPY --from=build /usr/src/app/FlashMQBuildRelease/FlashMQ /bin/FlashMQ
+
+EXPOSE 1883
+CMD ["/bin/FlashMQ"]


### PR DESCRIPTION
Not sure if you are interested in this, so feel absolutely free to close this PR.

I was trying to build arm64 Docker images via buildx, as I normally do. Sadly, because the Dockerfile has hardcoded references to x86_64, this failed.

So, I added some glue in the Dockerfile, allowing it to pick the right folders depending on the platform you are building for. I only added support for amd64 and arm64, as those are my target / and what I can test.
I put it in another Dockerfile, as the normal `docker build` doesn't understand this redirect via `$TARGETARCH`. They couldn't make this easy, ofc.

But, with that, buildx happily builds FlashMQ, and it even works on arm64 just fine :)