### PR TITLE
Fix deprecation warnings from CI

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -33,7 +33,7 @@ jobs:
     name: "${{ matrix.os }}: ${{ matrix.friendly }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: sudo apt update
       # Build prerequisites
       - run: sudo apt install docbook2x

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,5 +5,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: docker build .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: sudo apt install -y shellcheck
       - run: shellcheck debian/post* debian/pre*
       - run: find . -type f -iname '*.sh' -exec shellcheck '{}' '+'
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: sudo snap install mdl
         # Exclude MD013: line-length. If it looks good to the dev editing the Markdown file it's good enough for us
       - run: find . -type f -iname '*.md' -exec mdl --rules "~MD013" '{}' '+'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
     name: "${{ matrix.friendly }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: sudo apt update
       # Build prerequisites
       - run: sudo apt install -y cmake libssl-dev qtbase5-dev ${{ matrix.aptpkg }}


### PR DESCRIPTION
This fixes the warnings shown on the CI build summary ([example](https://github.com/halfgaar/FlashMQ/actions/runs/3482091105)):
> shellcheck
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

There's also a warning about Ubuntu 18 officially deprecated and being dropped by 2023/04/01 ([Ticket 6002](https://github.com/actions/runner-images/issues/6002)), this PR doesn't address that point.