### PR TITLE
Add `--fail-on-doc-failure` flag to `build.sh` script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ while [[ "$#" -gt 0 ]]; do
       FAIL_ON_DOC_FAILURE="yeah"
       shift
       ;;
-    -*|--*)
+    --*|-*)
       echo -e "\e[31mUnknown option: \e[1m$1\e[0m" >&2
       usage >&2
       exit 2
@@ -45,8 +45,7 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-make -C "$thisdir/man"
-if [[ "$?" -ne 0 ]]; then
+if ! make -C "$thisdir/man"; then
   if [[ -z "$FAIL_ON_DOC_FAILURE" ]]; then
     echo -e "\e[33mIgnoring failed man page builds; run \e[1m$script_name\e[22m with the \e[1m--fail-on-doc-failure\e[22m option to make such failures fatal.\e[0m"
   else

--- a/man/Makefile
+++ b/man/Makefile
@@ -23,7 +23,7 @@ clean:
 # DocBook 4 first.  Why not “just” directly author in DocBook 4?  DocBook 5 has
 # more powerful schemas (and thus validation).
 #
-#.PRECIOUS: %.dbk4  # Uncomment to keep intermediate `*.dbk4` files for debugging.
+#.SECONDARY: %.dbk4  # Uncomment to keep intermediate `*.dbk4` files for debugging.
 %.dbk4: %.dbk5
 	xsltproc db5to4/db5to4-withinfo.xsl $< > $@
 


### PR DESCRIPTION
@halfgaar came up with this flag in private conversation, and I thought it would be a good idea to implement it to have a mechanism to ensure that release pipelines always sport up-to-date man page builds.

Another minor change is that I substituted the `.PRECIOUS` commentd-out pseudo-target in the `Makefile` with `.SECONDARY`.  The latter is the “correct” way to keep intermediate files from being deleted, without getting attached to _faulty_, incomplete intermediate files resulting from crashes.