### PR TITLE
Documentation updates

### DIFF
--- a/man/flashmq.conf.5
+++ b/man/flashmq.conf.5
@@ -16,6 +16,8 @@ To set a parameter, its name must appear on a single line, followed by whitespac
 \*(T<\fBparameter\-name\fR\*(T>
 \fIparameter-value\fR
 .PP
+When setting boolean values, \*(T<yes/no\*(T>, \*(T<true/false\*(T> and \*(T<on/off\*(T> can all be used.
+.PP
 To configure the listeners, use \*(T<\fBlisten\fR\*(T> blocks, defined by { and }. See EXAMPLE LISTENERS for details.
 .PP
 Lines beginning with the hash character (\(lq\*(T<#\*(T>\(rq) and empty lines are ignored. Thus, a line can be commented out by prepending a \(lq\*(T<#\*(T>\(rq to it.

--- a/man/flashmq.conf.5
+++ b/man/flashmq.conf.5
@@ -1,11 +1,11 @@
-'\" -*- coding: us-ascii -*-
+.\" -*- coding: us-ascii -*-
 .if \n(.g .ds T< \\FC
 .if \n(.g .ds T> \\F[\n[.fam]]
 .de URL
 \\$2 \(la\\$1\(ra\\$3
 ..
 .if \n(.g .mso www.tmac
-.TH flashmq.conf 5 "3 February 2023" "" ""
+.TH flashmq.conf 5 "2 May 2023" "" ""
 .SH NAME
 flashmq.conf \- FlashMQ configuration file format
 .SH SYNOPSIS
@@ -35,14 +35,14 @@ and
 \*(T<\fBplugin_opt_*\fR\*(T> \fIvalue\fR 
 Options passed to the plugin \*(T<\fBinit()\fR\*(T> function.
 .TP 
-\*(T<\fBplugin_serialize_init\fR\*(T> \fIyes/no\fR 
+\*(T<\fBplugin_serialize_init\fR\*(T> \fItrue/false\fR 
 There could be circumstances where the plugin code is mostly thread-safe, but not on initialization. Libmysqlclient for instance, needs a one-time initialization. To add to the confusion, Qt hides that away.
 
 The plugin should preferrably be written with proper synchronization like that, but as a last resort, you can use this to synchronize initialization.
 
 Default value: \*(T<true\*(T>
 .TP 
-\*(T<\fBplugin_serialize_auth_checks\fR\*(T> \fIyes/no\fR 
+\*(T<\fBplugin_serialize_auth_checks\fR\*(T> \fItrue/false\fR 
 Like \*(T<\fBplugin_serialize_init\fR\*(T>, but then for all login and ACL checks.
 
 This option may be dropped at some point, because it negates much of the multi-core design. One may as well run with only one thread then.
@@ -61,20 +61,20 @@ This configuration parameter sets the path to FlashMQ's log file. If you omit th
 
 Default value: \*(T<\fI/var/log/flashmq/flashmq.log\fR\*(T>
 .TP 
-\*(T<\fBlog_debug\fR\*(T> \fIyes/no\fR 
+\*(T<\fBlog_debug\fR\*(T> \fItrue/false\fR 
 Debug logging obviously creates a lot of log noise, so should only be done to diagnose problems.
 
 Default value: \*(T<false\*(T>
 .TP 
-\*(T<\fBlog_subscriptions\fR\*(T> \fIyes/no\fR 
+\*(T<\fBlog_subscriptions\fR\*(T> \fItrue/false\fR 
 Default value: \*(T<false\*(T>
 .TP 
-\*(T<\fBallow_unsafe_clientid_chars\fR\*(T> \fIyes/no\fR 
+\*(T<\fBallow_unsafe_clientid_chars\fR\*(T> \fItrue/false\fR 
 If you have topics with client IDs in it, people can possibly manipulate your ACL checking by saying their client ID is 'John+foobar'. Audit your security before you allow this.
 
 Default value: \*(T<false\*(T>
 .TP 
-\*(T<\fBallow_unsafe_username_chars\fR\*(T> \fIyes/no\fR 
+\*(T<\fBallow_unsafe_username_chars\fR\*(T> \fItrue/false\fR 
 If you have topics with usernames in it, people can possibly manipulate your ACL checking by saying their username is 'John+foobar'. Audit your security before you allow this.
 
 Default value: \*(T<false\*(T>
@@ -92,7 +92,7 @@ Mosquitto up to version 1.6 uses the sha512 algorithm. Newer version use sha512-
 \*(T<\fBmosquitto_acl_file\fR\*(T> \fI/foo/bar/mosquitto_acl_file\fR 
 ACL (access control lists) for users, anonymous users and patterns expandable with %u (username) and %c (clientid). Format is Mosquitto's acl_file.
 .TP 
-\*(T<\fBallow_anonymous\fR\*(T> \fIyes/no\fR 
+\*(T<\fBallow_anonymous\fR\*(T> \fItrue/false\fR 
 Default value: \*(T<false\*(T>
 .TP 
 \*(T<\fBrlimit_nofile\fR\*(T> \fInumber\fR 
@@ -105,7 +105,7 @@ Expire sessions after this time. Setting to 0 disables it and is (MQTT3) standar
 
 Default value: \*(T<1209600\*(T>
 .TP 
-\*(T<\fBquiet\fR\*(T> \fIyes/no\fR 
+\*(T<\fBquiet\fR\*(T> \fItrue/false\fR 
 Don't log LOG_INFO and LOG_NOTICE. This is useful when you have a lot of foot traffic, because otherwise the log gets filled with connect/disconnect notices.
 
 Default value: \*(T<false\*(T>
@@ -146,7 +146,7 @@ If you want to have a different amount of worker threads then CPUs, you can set 
 
 Default value: \*(T<\fIauto\-detect\fR\*(T>
 .TP 
-\*(T<\fBwills_enabled\fR\*(T> \fIyes/no\fR 
+\*(T<\fBwills_enabled\fR\*(T> \fItrue/false\fR 
 When disabled, the server will not set last will and testament specified by connecting clients.
 
 Default value: \*(T<\fItrue\fR\*(T>
@@ -243,7 +243,7 @@ Specifying a chain makes the listener SSL, and also requires the \*(T<\fBprivkey
 \*(T<\fBprivkey\fR\*(T> \fI/foobar/server.key\fR 
 Specifying a private key makes the listener SSL, and also requires the \*(T<\fBfullchain\fR\*(T> to be set.
 .TP 
-\*(T<\fBhaproxy\fR\*(T> \fIyes/no\fR 
+\*(T<\fBhaproxy\fR\*(T> \fItrue/false\fR 
 Setting the listener to haproxy makes it expect the PROXY protocol and set client source address to the original client. Make sure this listener is private / firewalled, otherwise anybody can set a different source address.
 
 Note that HAProxy's server health checks only started using the 'local' specifier as of version 2.4. This means earlier version will pretend to be a client and break the connection, causing log spam.

--- a/man/flashmq.conf.5
+++ b/man/flashmq.conf.5
@@ -181,7 +181,7 @@ Default value: \*(T<\fI200\fR\*(T>
 \*(T<\fBwebsocket_set_real_ip_from\fR\*(T> \fIinet4_address/inet6_address\fR 
 HTTP proxies in front of the websocket listeners can set the \fIX-Real-IP\fR header to identify the original connecting client. With \*(T<\fBwebsocket_set_real_ip_from\fR\*(T> you can mark IP networks as trusted. By default, clients are not trusted, to avoid spoofing.
 
-You can repeat the option to allow for mutiple addresses. Valid notations are \fI1.2.3.4\fR, \fI1.2.3.4/16\fR, \fI1.2.0.0/16\fR, \fI2a01:1337::1\fR, \fI2a01:1337::1/64\fR, etc.
+You can repeat the option to allow for multiple addresses. Valid notations are \fI1.2.3.4\fR, \fI1.2.3.4/16\fR, \fI1.2.0.0/16\fR, \fI2a01:1337::1\fR, \fI2a01:1337::1/64\fR, etc.
 
 The header \fIX-Forwarded-For\fR is not used, because that's designed to contain a list of addresses, if applicable.
 

--- a/man/flashmq.conf.5.dbk5
+++ b/man/flashmq.conf.5.dbk5
@@ -373,7 +373,7 @@
               HTTP proxies in front of the websocket listeners can set the <replaceable>X-Real-IP</replaceable> header to identify the original connecting client. With <option>websocket_set_real_ip_from</option> you can mark IP networks as trusted. By default, clients are not trusted, to avoid spoofing.
           </para>
           <para>
-              You can repeat the option to allow for mutiple addresses. Valid notations are <replaceable>1.2.3.4</replaceable>, <replaceable>1.2.3.4/16</replaceable>, <replaceable>1.2.0.0/16</replaceable>, <replaceable>2a01:1337::1</replaceable>, <replaceable>2a01:1337::1/64</replaceable>, etc.
+              You can repeat the option to allow for multiple addresses. Valid notations are <replaceable>1.2.3.4</replaceable>, <replaceable>1.2.3.4/16</replaceable>, <replaceable>1.2.0.0/16</replaceable>, <replaceable>2a01:1337::1</replaceable>, <replaceable>2a01:1337::1/64</replaceable>, etc.
           </para>
           <para>
               The header <replaceable>X-Forwarded-For</replaceable> is not used, because that's designed to contain a list of addresses, if applicable.

--- a/man/flashmq.conf.5.dbk5
+++ b/man/flashmq.conf.5.dbk5
@@ -31,6 +31,9 @@
       <option>parameter-name</option> <replaceable>parameter-value</replaceable>
     </para>
     <para>
+      When setting boolean values, <literal>yes/no</literal>, <literal>true/false</literal> and <literal>on/off</literal> can all be used.
+    </para>
+    <para>
       To configure the listeners, use <option>listen</option> blocks, defined by { and }. See EXAMPLE LISTENERS for details.
     </para>
     <para>

--- a/man/flashmq.conf.5.dbk5
+++ b/man/flashmq.conf.5.dbk5
@@ -66,7 +66,7 @@
       </varlistentry>
 
       <varlistentry xml:id="plugin_serialize_init">
-        <term><option>plugin_serialize_init</option> <replaceable>yes/no</replaceable></term>
+        <term><option>plugin_serialize_init</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             There could be circumstances where the plugin code is mostly thread-safe, but not on initialization. Libmysqlclient for instance, needs a one-time initialization. To add to the confusion, Qt hides that away.
@@ -80,7 +80,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="plugin_serialize_auth_checks">
-        <term><option>plugin_serialize_auth_checks</option> <replaceable>yes/no</replaceable></term>
+        <term><option>plugin_serialize_auth_checks</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             Like <option>plugin_serialize_init</option>, but then for all login and ACL checks.
@@ -119,7 +119,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="log_debug">
-        <term><option>log_debug</option> <replaceable>yes/no</replaceable></term>
+        <term><option>log_debug</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             Debug logging obviously creates a lot of log noise, so should only be done to diagnose problems.
@@ -130,7 +130,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="log_subscriptions">
-        <term><option>log_subscriptions</option> <replaceable>yes/no</replaceable></term>
+        <term><option>log_subscriptions</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             Default value: <literal>false</literal>
@@ -138,7 +138,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="allow_unsafe_clientid_chars">
-        <term><option>allow_unsafe_clientid_chars</option> <replaceable>yes/no</replaceable></term>
+        <term><option>allow_unsafe_clientid_chars</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             If you have topics with client IDs in it, people can possibly manipulate your ACL checking by saying their client ID is 'John+foobar'. Audit your security before you allow this.
@@ -149,7 +149,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="allow_unsafe_username_chars">
-        <term><option>allow_unsafe_username_chars</option> <replaceable>yes/no</replaceable></term>
+        <term><option>allow_unsafe_username_chars</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             If you have topics with usernames in it, people can possibly manipulate your ACL checking by saying their username is 'John+foobar'. Audit your security before you allow this.
@@ -190,7 +190,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="allow_anonymous">
-        <term><option>allow_anonymous</option> <replaceable>yes/no</replaceable></term>
+        <term><option>allow_anonymous</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             Default value: <literal>false</literal>
@@ -220,7 +220,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="quiet">
-        <term><option>quiet</option> <replaceable>yes/no</replaceable></term>
+        <term><option>quiet</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             Don't log LOG_INFO and LOG_NOTICE. This is useful when you have a lot of foot traffic, because otherwise the log gets filled with connect/disconnect notices.
@@ -301,7 +301,7 @@
       </varlistentry>
 
       <varlistentry xml:id="wills_enabled">
-        <term><option>wills_enabled</option> <replaceable>yes/no</replaceable></term>
+        <term><option>wills_enabled</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             When disabled, the server will not set last will and testament specified by connecting clients.
@@ -509,7 +509,7 @@
         </listitem>
       </varlistentry>
       <varlistentry xml:id="haproxy">
-        <term><option>haproxy</option> <replaceable>yes/no</replaceable></term>
+        <term><option>haproxy</option> <replaceable>true/false</replaceable></term>
         <listitem>
           <para>
             Setting the listener to haproxy makes it expect the PROXY protocol and set client source address to the original client. Make sure this listener is private / firewalled, otherwise anybody can set a different source address.

--- a/man/flashmq.conf.5.html
+++ b/man/flashmq.conf.5.html
@@ -427,7 +427,7 @@
               HTTP proxies in front of the websocket listeners can set the <code class="replaceable">X-Real-IP</code> header to identify the original connecting client. With websocket_set_real_ip_from you can mark IP networks as trusted. By default, clients are not trusted, to avoid spoofing.
           </p>
           <p>
-              You can repeat the option to allow for mutiple addresses. Valid notations are <code class="replaceable">1.2.3.4</code>, <code class="replaceable">1.2.3.4/16</code>, <code class="replaceable">1.2.0.0/16</code>, <code class="replaceable">2a01:1337::1</code>, <code class="replaceable">2a01:1337::1/64</code>, etc.
+              You can repeat the option to allow for multiple addresses. Valid notations are <code class="replaceable">1.2.3.4</code>, <code class="replaceable">1.2.3.4/16</code>, <code class="replaceable">1.2.0.0/16</code>, <code class="replaceable">2a01:1337::1</code>, <code class="replaceable">2a01:1337::1/64</code>, etc.
           </p>
           <p>
               The header <code class="replaceable">X-Forwarded-For</code> is not used, because that's designed to contain a list of addresses, if applicable.

--- a/man/flashmq.conf.5.html
+++ b/man/flashmq.conf.5.html
@@ -87,6 +87,9 @@
       parameter-name <code class="replaceable">parameter-value</code>
     </p>
     <p>
+      When setting boolean values, <code class="literal">yes/no</code>, <code class="literal">true/false</code> and <code class="literal">on/off</code> can all be used.
+    </p>
+    <p>
       To configure the listeners, use listen blocks, defined by { and }. See EXAMPLE LISTENERS for details.
     </p>
     <p>

--- a/man/flashmq.conf.5.html
+++ b/man/flashmq.conf.5.html
@@ -120,7 +120,7 @@
       
 
       
-        <dt id="plugin_serialize_init">plugin_serialize_init <code class="replaceable">yes/no</code><a class="hash-anchor" href="#plugin_serialize_init">#</a></dt>
+        <dt id="plugin_serialize_init">plugin_serialize_init <code class="replaceable">true/false</code><a class="hash-anchor" href="#plugin_serialize_init">#</a></dt>
         <dd>
           <p>
             There could be circumstances where the plugin code is mostly thread-safe, but not on initialization. Libmysqlclient for instance, needs a one-time initialization. To add to the confusion, Qt hides that away.
@@ -134,7 +134,7 @@
         </dd>
       
       
-        <dt id="plugin_serialize_auth_checks">plugin_serialize_auth_checks <code class="replaceable">yes/no</code><a class="hash-anchor" href="#plugin_serialize_auth_checks">#</a></dt>
+        <dt id="plugin_serialize_auth_checks">plugin_serialize_auth_checks <code class="replaceable">true/false</code><a class="hash-anchor" href="#plugin_serialize_auth_checks">#</a></dt>
         <dd>
           <p>
             Like plugin_serialize_init, but then for all login and ACL checks.
@@ -173,7 +173,7 @@
         </dd>
       
       
-        <dt id="log_debug">log_debug <code class="replaceable">yes/no</code><a class="hash-anchor" href="#log_debug">#</a></dt>
+        <dt id="log_debug">log_debug <code class="replaceable">true/false</code><a class="hash-anchor" href="#log_debug">#</a></dt>
         <dd>
           <p>
             Debug logging obviously creates a lot of log noise, so should only be done to diagnose problems.
@@ -184,7 +184,7 @@
         </dd>
       
       
-        <dt id="log_subscriptions">log_subscriptions <code class="replaceable">yes/no</code><a class="hash-anchor" href="#log_subscriptions">#</a></dt>
+        <dt id="log_subscriptions">log_subscriptions <code class="replaceable">true/false</code><a class="hash-anchor" href="#log_subscriptions">#</a></dt>
         <dd>
           <p>
             Default value: <code class="literal">false</code>
@@ -192,7 +192,7 @@
         </dd>
       
       
-        <dt id="allow_unsafe_clientid_chars">allow_unsafe_clientid_chars <code class="replaceable">yes/no</code><a class="hash-anchor" href="#allow_unsafe_clientid_chars">#</a></dt>
+        <dt id="allow_unsafe_clientid_chars">allow_unsafe_clientid_chars <code class="replaceable">true/false</code><a class="hash-anchor" href="#allow_unsafe_clientid_chars">#</a></dt>
         <dd>
           <p>
             If you have topics with client IDs in it, people can possibly manipulate your ACL checking by saying their client ID is 'John+foobar'. Audit your security before you allow this.
@@ -203,7 +203,7 @@
         </dd>
       
       
-        <dt id="allow_unsafe_username_chars">allow_unsafe_username_chars <code class="replaceable">yes/no</code><a class="hash-anchor" href="#allow_unsafe_username_chars">#</a></dt>
+        <dt id="allow_unsafe_username_chars">allow_unsafe_username_chars <code class="replaceable">true/false</code><a class="hash-anchor" href="#allow_unsafe_username_chars">#</a></dt>
         <dd>
           <p>
             If you have topics with usernames in it, people can possibly manipulate your ACL checking by saying their username is 'John+foobar'. Audit your security before you allow this.
@@ -244,7 +244,7 @@
         </dd>
       
       
-        <dt id="allow_anonymous">allow_anonymous <code class="replaceable">yes/no</code><a class="hash-anchor" href="#allow_anonymous">#</a></dt>
+        <dt id="allow_anonymous">allow_anonymous <code class="replaceable">true/false</code><a class="hash-anchor" href="#allow_anonymous">#</a></dt>
         <dd>
           <p>
             Default value: <code class="literal">false</code>
@@ -274,7 +274,7 @@
         </dd>
       
       
-        <dt id="quiet">quiet <code class="replaceable">yes/no</code><a class="hash-anchor" href="#quiet">#</a></dt>
+        <dt id="quiet">quiet <code class="replaceable">true/false</code><a class="hash-anchor" href="#quiet">#</a></dt>
         <dd>
           <p>
             Don't log LOG_INFO and LOG_NOTICE. This is useful when you have a lot of foot traffic, because otherwise the log gets filled with connect/disconnect notices.
@@ -355,7 +355,7 @@
       
 
       
-        <dt id="wills_enabled">wills_enabled <code class="replaceable">yes/no</code><a class="hash-anchor" href="#wills_enabled">#</a></dt>
+        <dt id="wills_enabled">wills_enabled <code class="replaceable">true/false</code><a class="hash-anchor" href="#wills_enabled">#</a></dt>
         <dd>
           <p>
             When disabled, the server will not set last will and testament specified by connecting clients.
@@ -561,7 +561,7 @@
         </dd>
       
       
-        <dt id="haproxy">haproxy <code class="replaceable">yes/no</code><a class="hash-anchor" href="#haproxy">#</a></dt>
+        <dt id="haproxy">haproxy <code class="replaceable">true/false</code><a class="hash-anchor" href="#haproxy">#</a></dt>
         <dd>
           <p>
             Setting the listener to haproxy makes it expect the PROXY protocol and set client source address to the original client. Make sure this listener is private / firewalled, otherwise anybody can set a different source address.


### PR DESCRIPTION
- Fixed a typo
- Made boolean options in the documentation consistent with the default value
- Added explanation about the interchangeability between boolean values