### PR TITLE
Tighten config parser

### DIFF
--- a/FlashMQTests/CMakeLists.txt
+++ b/FlashMQTests/CMakeLists.txt
@@ -162,6 +162,7 @@ add_executable(flashmq-tests
     conffiletemp.cpp conffiletemp.h
     filecloser.cpp filecloser.h
     plugintests.cpp
+    configtests.cpp
     sharedsubscriptionstests.cpp
     websockettests.cpp
     willtests.cpp

--- a/FlashMQTests/configtests.cpp
+++ b/FlashMQTests/configtests.cpp
@@ -1,0 +1,119 @@
+#include "maintests.h"
+#include "testhelpers.h"
+#include "conffiletemp.h"
+#include "exceptions.h"
+
+void MainTests::test_loading_second_value()
+{
+    /* this is expected to work*/
+    {
+        ConfFileTemp config;
+        config.writeLine("bridge {");
+        config.writeLine("  address localhost");
+        config.writeLine("  publish send/this 1"); // this value should be different from the default (0)
+        config.writeLine("}");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+        parser.loadFile(false);
+
+        Settings settings = parser.getSettings();
+
+        std::shared_ptr<BridgeConfig> bridge = settings.stealBridges().front();
+
+        FMQ_COMPARE(bridge->publishes[0].topic, "send/this");
+        FMQ_COMPARE(bridge->publishes[0].qos, (uint8_t)1);
+    }
+
+    /* this is expecte to fail because "address" doesn't take a second value */
+    {
+        ConfFileTemp config;
+        config.writeLine("bridge {");
+        config.writeLine("  address localhost thisisnotok");
+        config.writeLine("  publish send/this 1");
+        config.writeLine("}");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+        try
+        {
+            parser.loadFile(false);
+            FMQ_FAIL("The config parser is too liberal");
+        }
+        catch (ConfigFileException &ex)
+        {
+            /* Excellent, what we wanted */
+        }
+    }
+}
+
+void MainTests::test_parsing_numbers()
+{
+    /* this should work: 180 */
+    {
+        ConfFileTemp config;
+        config.writeLine("expire_sessions_after_seconds 180");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+        parser.loadFile(false);
+
+        Settings settings = parser.getSettings();
+
+        FMQ_COMPARE(settings.expireSessionsAfterSeconds, (uint32_t)180);
+    }
+
+    /* this should fail: 180days */
+    {
+        ConfFileTemp config;
+        config.writeLine("expire_sessions_after_seconds 180days");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+        try
+        {
+            parser.loadFile(false);
+            FMQ_FAIL("The parser was too liberal");
+        }
+        catch (ConfigFileException&)
+        {
+            /* Good! This is where we want to end up in */
+        }
+    }
+
+    /* this should also fail: 180 days */
+    {
+        ConfFileTemp config;
+        config.writeLine("expire_sessions_after_seconds 180 days");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+        try
+        {
+            parser.loadFile(false);
+            FMQ_FAIL("The parser was too liberal");
+        }
+        catch (ConfigFileException&)
+        {
+            /* Good! This is where we want to end up in */
+        }
+    }
+
+    /* Last one that should fail: 180 days and a bit */
+    {
+        ConfFileTemp config;
+        config.writeLine("expire_sessions_after_seconds 180 days and a bit more");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+        try
+        {
+            parser.loadFile(false);
+            FMQ_FAIL("The parser was too liberal");
+        }
+        catch (ConfigFileException&)
+        {
+            /* Good! This is where we want to end up in */
+        }
+    }
+}

--- a/FlashMQTests/maintests.cpp
+++ b/FlashMQTests/maintests.cpp
@@ -184,6 +184,8 @@ MainTests::MainTests()
     REGISTER_FUNCTION(test_acl_patterns_username);
     REGISTER_FUNCTION(test_acl_patterns_clientid);
     REGISTER_FUNCTION(test_loading_acl_file);
+    REGISTER_FUNCTION(test_loading_second_value);
+    REGISTER_FUNCTION(test_parsing_numbers);
     REGISTER_FUNCTION(test_validUtf8Generic);
 
 #ifndef FMQ_NO_SSE

--- a/FlashMQTests/maintests.h
+++ b/FlashMQTests/maintests.h
@@ -69,6 +69,8 @@ class MainTests
     void test_acl_patterns_clientid();
     void test_loading_acl_file();
 
+    void test_loading_second_value();
+    void test_parsing_numbers();
     void test_validUtf8Generic();
 
 #ifndef FMQ_NO_SSE

--- a/configfileparser.h
+++ b/configfileparser.h
@@ -42,6 +42,7 @@ class ConfigFileParser
 
     Settings settings;
 
+    void static testCorrectNumberOfValues(const std::string &key, size_t expected_values, const std::smatch &matches);
     bool testKeyValidity(const std::string &key, const std::string &matchKey, const std::set<std::string> &validKeys) const;
     void static checkFileExistsAndReadable(const std::string &key, const std::string &pathToCheck, ssize_t max_size = std::numeric_limits<ssize_t>::max());
     void static checkFileOrItsDirWritable(const std::string &filepath);


### PR DESCRIPTION
While mucking around with the codebase I discovered the configuration parser is rather liberal. Example configs that were OK:

```conf
expire_sessions_after_seconds 180h
expire_sessions_after_seconds 180 hours
```

In both cases the value is 180 seconds: the extra text is fully ignored.

This had two causes:
* [std::stoi](https://en.cppreference.com/w/cpp/string/basic_string/stol) and friends can leave a part of the string unparsed. To fix this I made a `full_stoi` that checks how much work was done to ensure the entire value was used for the conversion
* `key_value_regex` scans for lines with 3 values, of which the third one is optional. I'd guess this was done to support the QoS of `publish` / `subscribe` (which aren't documented btw), but caused every other setting to accept and ignore a third value. To make the smallest possible changeset I fixed this by adding a check at the bottom using a new var called `number_of_expected_values`. A nicer solution would be to add a new regex but that requires far more changes to the code.

Please double-check the correctness: it's good enough to compile and to pass nearly all testcases* but I'm not intimately familiar with the FlashMQ codebase.

<sub>* `testRetainedAclReadCheck` fails with `plugins/libtest_plugin.so.0.0.1 is not there` which seem unrelated to my changes</sub>