### PR TITLE
Standardize CMakeLists files

### DIFF
--- a/CMakeLists.shared
+++ b/CMakeLists.shared
@@ -1,0 +1,134 @@
+# This file is shared between FlashMQ itself and FlashMQTests
+# It should not contain any definitions that isn't used by both
+
+# When building FlashMQTests:
+# CMAKE_CURRENT_SOURCE_DIR -> /home/user/FlashMQ/FlashMQTests
+# CMAKE_CURRENT_LIST_DIR   -> /home/user/FlashMQ
+#
+# When building FlashMQ:
+# CMAKE_CURRENT_SOURCE_DIR -> /home/user/FlashMQ
+# CMAKE_CURRENT_LIST_DIR   -> /home/user/FlashMQ
+
+if (CMAKE_CURRENT_LIST_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(RELPATH "./")
+else()
+    set(RELPATH "../")
+endif()
+
+message("Determined RELPATH: ${RELPATH}")
+
+set(FLASHMQ_HEADERS
+    ${RELPATH}forward_declarations.h
+    ${RELPATH}mainapp.h
+    ${RELPATH}utils.h
+    ${RELPATH}threaddata.h
+    ${RELPATH}client.h
+    ${RELPATH}session.h
+    ${RELPATH}mqttpacket.h
+    ${RELPATH}exceptions.h
+    ${RELPATH}types.h
+    ${RELPATH}subscriptionstore.h
+    ${RELPATH}rwlockguard.h
+    ${RELPATH}retainedmessage.h
+    ${RELPATH}cirbuf.h
+    ${RELPATH}logger.h
+    ${RELPATH}plugin.h
+    ${RELPATH}configfileparser.h
+    ${RELPATH}sslctxmanager.h
+    ${RELPATH}timer.h
+    ${RELPATH}iowrapper.h
+    ${RELPATH}mosquittoauthoptcompatwrap.h
+    ${RELPATH}settings.h
+    ${RELPATH}listener.h
+    ${RELPATH}unscopedlock.h
+    ${RELPATH}scopedsocket.h
+    ${RELPATH}bindaddr.h
+    ${RELPATH}oneinstancelock.h
+    ${RELPATH}evpencodectxmanager.h
+    ${RELPATH}acltree.h
+    ${RELPATH}enums.h
+    ${RELPATH}threadlocalutils.h
+    ${RELPATH}flashmq_plugin.h
+    ${RELPATH}retainedmessagesdb.h
+    ${RELPATH}persistencefile.h
+    ${RELPATH}sessionsandsubscriptionsdb.h
+    ${RELPATH}qospacketqueue.h
+    ${RELPATH}threadglobals.h
+    ${RELPATH}threadloop.h
+    ${RELPATH}publishcopyfactory.h
+    ${RELPATH}variablebyteint.h
+    ${RELPATH}mqtt5properties.h
+    ${RELPATH}globalstats.h
+    ${RELPATH}derivablecounter.h
+    ${RELPATH}packetdatatypes.h
+    ${RELPATH}haproxy.h
+    ${RELPATH}network.h
+    ${RELPATH}subscription.h
+    ${RELPATH}sharedsubscribers.h
+    ${RELPATH}pluginloader.h
+    ${RELPATH}queuedtasks.h
+    ${RELPATH}acksender.h
+    ${RELPATH}bridgeconfig.h
+    ${RELPATH}dnsresolver.h
+    ${RELPATH}globber.h
+    ${RELPATH}bridgeinfodb.h
+    ${RELPATH}x509manager.h
+    ${RELPATH}backgroundworker.h
+)
+
+set(FLASHMQ_IMPLS
+    ${RELPATH}mainapp.cpp
+    ${RELPATH}utils.cpp
+    ${RELPATH}threaddata.cpp
+    ${RELPATH}client.cpp
+    ${RELPATH}session.cpp
+    ${RELPATH}mqttpacket.cpp
+    ${RELPATH}exceptions.cpp
+    ${RELPATH}types.cpp
+    ${RELPATH}subscriptionstore.cpp
+    ${RELPATH}rwlockguard.cpp
+    ${RELPATH}retainedmessage.cpp
+    ${RELPATH}cirbuf.cpp
+    ${RELPATH}logger.cpp
+    ${RELPATH}plugin.cpp
+    ${RELPATH}configfileparser.cpp
+    ${RELPATH}sslctxmanager.cpp
+    ${RELPATH}timer.cpp
+    ${RELPATH}iowrapper.cpp
+    ${RELPATH}mosquittoauthoptcompatwrap.cpp
+    ${RELPATH}settings.cpp
+    ${RELPATH}listener.cpp
+    ${RELPATH}unscopedlock.cpp
+    ${RELPATH}scopedsocket.cpp
+    ${RELPATH}bindaddr.cpp
+    ${RELPATH}oneinstancelock.cpp
+    ${RELPATH}evpencodectxmanager.cpp
+    ${RELPATH}acltree.cpp
+    ${RELPATH}threadlocalutils.cpp
+    ${RELPATH}flashmq_plugin.cpp
+    ${RELPATH}retainedmessagesdb.cpp
+    ${RELPATH}persistencefile.cpp
+    ${RELPATH}sessionsandsubscriptionsdb.cpp
+    ${RELPATH}qospacketqueue.cpp
+    ${RELPATH}threadglobals.cpp
+    ${RELPATH}threadloop.cpp
+    ${RELPATH}publishcopyfactory.cpp
+    ${RELPATH}variablebyteint.cpp
+    ${RELPATH}mqtt5properties.cpp
+    ${RELPATH}globalstats.cpp
+    ${RELPATH}derivablecounter.cpp
+    ${RELPATH}packetdatatypes.cpp
+    ${RELPATH}haproxy.cpp
+    ${RELPATH}network.cpp
+    ${RELPATH}subscription.cpp
+    ${RELPATH}sharedsubscribers.cpp
+    ${RELPATH}pluginloader.cpp
+    ${RELPATH}queuedtasks.cpp
+    ${RELPATH}acksender.cpp
+    ${RELPATH}bridgeconfig.cpp
+    ${RELPATH}dnsresolver.cpp
+    ${RELPATH}bridgeinfodb.cpp
+    ${RELPATH}globber.cpp
+    ${RELPATH}x509manager.cpp
+    ${RELPATH}backgroundworker.cpp
+    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW)
 include(CheckCXXCompilerFlag)
+include(CMakeLists.shared)
 
 project(FlashMQ VERSION 1.10.0 LANGUAGES CXX)
 
@@ -24,117 +25,10 @@ endif()
 add_compile_options(-Wall)
 
 add_executable(flashmq
-    forward_declarations.h
-    mainapp.h
-    utils.h
-    threaddata.h
-    client.h
-    session.h
-    mqttpacket.h
-    exceptions.h
-    types.h
-    subscriptionstore.h
-    rwlockguard.h
-    retainedmessage.h
-    cirbuf.h
-    logger.h
-    plugin.h
-    configfileparser.h
-    sslctxmanager.h
-    timer.h
-    iowrapper.h
-    mosquittoauthoptcompatwrap.h
-    settings.h
-    listener.h
-    unscopedlock.h
-    scopedsocket.h
-    bindaddr.h
-    oneinstancelock.h
-    evpencodectxmanager.h
-    acltree.h
-    enums.h
-    threadlocalutils.h
-    flashmq_plugin.h
-    retainedmessagesdb.h
-    persistencefile.h
-    sessionsandsubscriptionsdb.h
-    qospacketqueue.h
-    threadglobals.h
-    threadloop.h
-    publishcopyfactory.h
-    variablebyteint.h
-    mqtt5properties.h
-    globalstats.h
-    derivablecounter.h
-    packetdatatypes.h
-    haproxy.h
-    network.h
-    subscription.h
-    sharedsubscribers.h
-    pluginloader.h
-    queuedtasks.h
-    acksender.h
-    bridgeconfig.h
-    dnsresolver.h
-    globber.h
+    ${FLASHMQ_HEADERS}
+    ${FLASHMQ_IMPLS}
 
-
-    mainapp.cpp
     main.cpp
-    utils.cpp
-    threaddata.cpp
-    client.cpp
-    session.cpp
-    mqttpacket.cpp
-    exceptions.cpp
-    types.cpp
-    subscriptionstore.cpp
-    rwlockguard.cpp
-    retainedmessage.cpp
-    cirbuf.cpp
-    logger.cpp
-    plugin.cpp
-    configfileparser.cpp
-    sslctxmanager.cpp
-    timer.cpp
-    iowrapper.cpp
-    mosquittoauthoptcompatwrap.cpp
-    settings.cpp
-    listener.cpp
-    unscopedlock.cpp
-    scopedsocket.cpp
-    bindaddr.cpp
-    oneinstancelock.cpp
-    evpencodectxmanager.cpp
-    acltree.cpp
-    threadlocalutils.cpp
-    flashmq_plugin.cpp
-    retainedmessagesdb.cpp
-    persistencefile.cpp
-    sessionsandsubscriptionsdb.cpp
-    qospacketqueue.cpp
-    threadglobals.cpp
-    threadloop.cpp
-    publishcopyfactory.cpp
-    variablebyteint.cpp
-    mqtt5properties.cpp
-    globalstats.cpp
-    derivablecounter.cpp
-    packetdatatypes.cpp
-    haproxy.cpp
-    network.cpp
-    subscription.cpp
-    sharedsubscribers.cpp
-    pluginloader.cpp
-    queuedtasks.cpp
-    acksender.cpp
-    bridgeconfig.cpp
-    dnsresolver.cpp
-    bridgeinfodb.h bridgeinfodb.cpp
-    globber.cpp
-    x509manager.h x509manager.cpp
-    backgroundworker.h backgroundworker.cpp
-
     )
 
 target_link_libraries(flashmq pthread dl ssl crypto resolv anl)

--- a/FlashMQTests/CMakeLists.txt
+++ b/FlashMQTests/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW)
 include(CheckCXXCompilerFlag)
+include(../CMakeLists.shared)
 
 project(FlashMQTests VERSION 1.0.0 LANGUAGES CXX)
 
@@ -41,116 +42,9 @@ add_custom_command(TARGET test_plugin POST_BUILD COMMAND ${CMAKE_COMMAND} -E cop
     "${CMAKE_BINARY_DIR}/plainwebsocketpacket1_handshake.dat")
 
 add_executable(flashmq-tests
-    ../forward_declarations.h
-    ../mainapp.h
-    ../utils.h
-    ../threaddata.h
-    ../client.h
-    ../session.h
-    ../mqttpacket.h
-    ../exceptions.h
-    ../types.h
-    ../subscriptionstore.h
-    ../rwlockguard.h
-    ../retainedmessage.h
-    ../cirbuf.h
-    ../logger.h
-    ../plugin.h
-    ../configfileparser.h
-    ../sslctxmanager.h
-    ../timer.h
-    ../iowrapper.h
-    ../mosquittoauthoptcompatwrap.h
-    ../settings.h
-    ../listener.h
-    ../unscopedlock.h
-    ../scopedsocket.h
-    ../bindaddr.h
-    ../oneinstancelock.h
-    ../evpencodectxmanager.h
-    ../acltree.h
-    ../enums.h
-    ../threadlocalutils.h
-    ../flashmq_plugin.h
-    ../retainedmessagesdb.h
-    ../persistencefile.h
-    ../sessionsandsubscriptionsdb.h
-    ../qospacketqueue.h
-    ../threadglobals.h
-    ../threadloop.h
-    ../publishcopyfactory.h
-    ../variablebyteint.h
-    ../mqtt5properties.h
-    ../globalstats.h
-    ../derivablecounter.h
-    ../packetdatatypes.h
-    ../haproxy.h
-    ../network.h
-    ../subscription.h
-    ../sharedsubscribers.h
-    ../pluginloader.h
-    ../queuedtasks.h
-    ../acksender.h
-    ../bridgeconfig.h
-    ../dnsresolver.h
-    ../globber.h
+    ${FLASHMQ_HEADERS}
+    ${FLASHMQ_IMPLS}
 
-    ../mainapp.cpp
-    ../utils.cpp
-    ../threaddata.cpp
-    ../client.cpp
-    ../session.cpp
-    ../mqttpacket.cpp
-    ../exceptions.cpp
-    ../types.cpp
-    ../subscriptionstore.cpp
-    ../rwlockguard.cpp
-    ../retainedmessage.cpp
-    ../cirbuf.cpp
-    ../logger.cpp
-    ../plugin.cpp
-    ../configfileparser.cpp
-    ../sslctxmanager.cpp
-    ../timer.cpp
-    ../iowrapper.cpp
-    ../mosquittoauthoptcompatwrap.cpp
-    ../settings.cpp
-    ../listener.cpp
-    ../unscopedlock.cpp
-    ../scopedsocket.cpp
-    ../bindaddr.cpp
-    ../oneinstancelock.cpp
-    ../evpencodectxmanager.cpp
-    ../acltree.cpp
-    ../threadlocalutils.cpp
-    ../flashmq_plugin.cpp
-    ../retainedmessagesdb.cpp
-    ../persistencefile.cpp
-    ../sessionsandsubscriptionsdb.cpp
-    ../qospacketqueue.cpp
-    ../threadglobals.cpp
-    ../threadloop.cpp
-    ../publishcopyfactory.cpp
-    ../variablebyteint.cpp
-    ../mqtt5properties.cpp
-    ../globalstats.cpp
-    ../derivablecounter.cpp
-    ../packetdatatypes.cpp
-    ../haproxy.cpp
-    ../network.cpp
-    ../subscription.cpp
-    ../sharedsubscribers.cpp
-    ../pluginloader.cpp
-    ../queuedtasks.cpp
-    ../acksender.cpp
-    ../bridgeconfig.cpp
-    ../dnsresolver.cpp
-    ../bridgeinfodb.h
-    ../bridgeinfodb.cpp
-    ../globber.cpp
-    ../x509manager.h
-    ../x509manager.cpp
-    ../backgroundworker.h ../backgroundworker.cpp
     ../flashmqtestclient.cpp ../flashmqtestclient.h
     main.cpp
     mainappinthread.h mainappinthread.cpp


### PR DESCRIPTION
By putting the common definitions in a shared file it's less painful to keep both projects compiling.