### PR TITLE
WIP / config suggestions

### DIFF
--- a/FlashMQTests/configtests.cpp
+++ b/FlashMQTests/configtests.cpp
@@ -117,3 +117,56 @@ void MainTests::test_parsing_numbers()
         }
     }
 }
+
+void MainTests::testStringDistances()
+{
+    FMQ_COMPARE(distanceBetweenStrings("", ""), (unsigned int)0);
+    FMQ_COMPARE(distanceBetweenStrings("dog", ""), (unsigned int)3);
+    FMQ_COMPARE(distanceBetweenStrings("", "dog"), (unsigned int)3);
+    FMQ_COMPARE(distanceBetweenStrings("dog", "horse"), (unsigned int)4);
+    FMQ_COMPARE(distanceBetweenStrings("horse", "dog"), (unsigned int)4);
+    FMQ_COMPARE(distanceBetweenStrings("industry", "interest"), (unsigned int)6);
+    FMQ_COMPARE(distanceBetweenStrings("kitten", "sitting"), (unsigned int)3);
+    FMQ_COMPARE(distanceBetweenStrings("uninformed", "uniformed"), (unsigned int)1);
+}
+
+void MainTests::testConfigSuggestion()
+{
+    // User made a small typo: 'session' instead of 'sessions'
+    {
+        ConfFileTemp config;
+        config.writeLine("expire_session_after_seconds 180");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+
+        try
+        {
+            parser.loadFile(false);
+            FMQ_FAIL("The parser is too liberal");
+        }
+        catch (ConfigFileException &ex)
+        {
+            FMQ_COMPARE(ex.what(), "Config key 'expire_session_after_seconds' is not valid (here). Did you mean: expire_sessions_after_seconds ?");
+        }
+    }
+
+    // User entered gibberish. Let's not suggest gibberish back
+    {
+        ConfFileTemp config;
+        config.writeLine("foobarbaz 180");
+        config.closeFile();
+
+        ConfigFileParser parser(config.getFilePath());
+
+        try
+        {
+            parser.loadFile(false);
+            FMQ_FAIL("The parser is too liberal");
+        }
+        catch (ConfigFileException &ex)
+        {
+            FMQ_COMPARE(ex.what(), "Config key 'foobarbaz' is not valid (here).");
+        }
+    }
+}

--- a/FlashMQTests/maintests.cpp
+++ b/FlashMQTests/maintests.cpp
@@ -231,6 +231,8 @@ MainTests::MainTests()
     REGISTER_FUNCTION(testOverrideWillDelayOnSessionDestructionByTakeOver);
     REGISTER_FUNCTION(testDisabledWills);
     REGISTER_FUNCTION(testMqtt5DelayedWillsDisabled);
+    REGISTER_FUNCTION(testStringDistances);
+    REGISTER_FUNCTION(testConfigSuggestion);
     REGISTER_FUNCTION(testIncomingTopicAlias);
     REGISTER_FUNCTION(testOutgoingTopicAlias);
     REGISTER_FUNCTION(testOutgoingTopicAliasBeyondMax);

--- a/FlashMQTests/maintests.h
+++ b/FlashMQTests/maintests.h
@@ -120,6 +120,8 @@ class MainTests
     void testOverrideWillDelayOnSessionDestructionByTakeOver();
     void testDisabledWills();
     void testMqtt5DelayedWillsDisabled();
+    void testStringDistances();
+    void testConfigSuggestion();
 
 
     void testIncomingTopicAlias();

--- a/FlashMQTests/testhelpers.cpp
+++ b/FlashMQTests/testhelpers.cpp
@@ -1,6 +1,7 @@
 #include "testhelpers.h"
 
 #include <iostream>
+#include <cstring>
 
 int assert_count;
 int assert_fail_count;
@@ -16,8 +17,21 @@ bool fmq_assert(bool b, const char *failmsg, const char *actual, const char *exp
 
         if (asserts_print)
         {
-            std::cout << RED << "FAIL" << COLOR_END << ": '" << failmsg << "', " << actual << " != " << expected << std::endl
-                      << " in " << file << ", line " << line << std::endl;
+            // There are two types of failmsg: unformatted ones and formatted ones.
+            // By testing for a newline we can detect formatted ones.
+            if (strchr(failmsg, '\n') == nullptr)
+            {
+                // unformatted
+                std::cout << RED << "FAIL" << COLOR_END << ": '" << failmsg << "', " << actual << " != " << expected << std::endl
+                          << " in " << file << ", line " << line << std::endl;
+            }
+            else
+            {
+                // formatted
+                std::cout << RED << "FAIL" << COLOR_END << " in " << file << ", line " << line << std::endl;
+                std::cout << failmsg << std::endl;
+                std::cout << "Comparison: " << actual << " != " << expected << std::endl;
+            }
         }
     }
 

--- a/FlashMQTests/testhelpers.h
+++ b/FlashMQTests/testhelpers.h
@@ -61,7 +61,17 @@ inline bool fmq_compare(const char *c1, const char *c2, const char *actual, cons
     std::string s2(c2);
 
     std::ostringstream oss;
-    oss << s1 << " != " << s2;
+
+    if (s1.length() + s2.length() < 100)
+    {
+        // short form
+        oss << s1 << " != " << s2;
+    }
+    else
+    {
+        oss << "Actual:     " << s1 << std::endl;
+        oss << "Expected:   " << s2;
+    }
 
     return fmq_assert(s1 == s2, oss.str().c_str(), actual, expected, file, line);
 }

--- a/configfileparser.cpp
+++ b/configfileparser.cpp
@@ -93,6 +93,33 @@ bool ConfigFileParser::testKeyValidity(const std::string &key, const std::string
     {
         std::ostringstream oss;
         oss << "Config key '" << key << "' is not valid (here).";
+
+        // Maybe the user made a typo
+        auto alternative = validKeys.end();
+        unsigned int alternative_distance = UINT_MAX;
+
+        for (auto possible_key = validKeys.begin(); possible_key != validKeys.end(); ++possible_key)
+        {
+            unsigned int distance = distanceBetweenStrings(key.c_str(), *possible_key);
+            // We only want to suggest options that look a bit like the unknown
+            // one. Experimentally I found 50% of the total length a decent
+            // cutoff.
+            //
+            // The mathemathical formula "distance/length < 0.5" can be
+            // approximated with integers as "distance*2/length < 1"
+            if ((distance * 2) / key.length() < 1 && distance < alternative_distance)
+            {
+                alternative = possible_key;
+                alternative_distance = distance;
+            }
+        }
+        if (alternative != validKeys.end())
+        {
+            // It might indeed have been a typo.
+            // The space before the question mark is to make copying using mouse-double-click possible.
+            oss << " Did you mean: " << alternative->c_str() << " ?";
+        }
+
         throw ConfigFileException(oss.str());
     }
 

--- a/utils.h
+++ b/utils.h
@@ -124,6 +124,8 @@ std::string websocketCloseCodeToString(uint16_t code);
 
 std::string protocolVersionString(ProtocolVersion p);
 
+unsigned int distanceBetweenStrings(const std::string &stringA, const std::string &stringB);
+
 uint32_t ageFromTimePoint(const std::chrono::time_point<std::chrono::steady_clock> &point);
 std::chrono::time_point<std::chrono::steady_clock> timepointFromAge(const uint32_t age);
 


### PR DESCRIPTION
Kind of ready if you don't mind me hacking around in `FMQ_COMPARE`

---

This branch modifies FlashMQ so that it will suggest possible fixes when an unknown configuration keyword is found. For example, when the user makes a typo and writes `session` instead of `sessions`:
> Config key 'expire_session_after_seconds' is not valid (here). Did you mean: expire_sessions_after_seconds ?

The way it works: when an unknown key is found a list of all valid keys within that context are compared to the unknown key, and the one with the shortest reasonable [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) is suggested. This distance expresses how many insertions/substitutions/deletions are needed to go from 1 word to another. In the example above the distance is 1: if you insert an `s` in the right place the words match.

---

Open questions:

* ~~The library I used to calculate the distance, `edlib`, is licensed under the Expat license ("MIT"). I think it's fine for you to use it like this but I'm not a lawyer~~
* ~~This feature adds a lot of code, primarily in the `edlib`. The lib looks clean and well documented but I'm not capable of assessing its quality / exploitability. If you want to replace it with another library, now or in the future, it's quite straightforward though: any library that gives you a distance value can be plugged in~~
* ~~If you want this feature and this lib: how do you want to store it in the repo? git submodules, the current setup, a single `3rdparty` dir that contains the `.h` and `.cpp`, throw the files in the root dir?~~
* `FMQ_COMPARE` was okay for comparing short words but the output was very hard to read when asserting entire sentences. I therefore hacked the `fmq_assert` method to support 2 types of output, one with newlines and one without newlines. This is rather ugly, but I'm not sure how else to solve it. I could create an `FMQ_COMPARE_VERBOSE` with an extra underlying `fmq_assert_verbose` but that sounds like it will result in duplicate code etc. Perhaps I could add a boolean argument for `fmq_assert` that activates when used with a new `FMQ_COMPARE_VERBOSE`, would that be nicer?
* ~~Before merging I'll have to rebase it on master, it's currently rebased on a feature branch of mine (which I anticipate will get merged into master soonish)~~ the other branch has landed and this branch has been rebased on your master