### PR TITLE
Add option to set listener socket(s) to `TCP_NODELAY` mode

### DIFF
--- a/bridgeconfig.cpp
+++ b/bridgeconfig.cpp
@@ -192,7 +192,7 @@ bool BridgeConfig::operator ==(const BridgeConfig &other) const
            && this->localCleanStart == other.localCleanStart && this->remoteSessionExpiryInterval == other.remoteSessionExpiryInterval
            && this->localSessionExpiryInterval == other.localSessionExpiryInterval && this->remoteRetainAvailable == other.remoteRetainAvailable
            && this->useSavedClientId == other.useSavedClientId && this->maxOutgoingTopicAliases == other.maxOutgoingTopicAliases
-           && this->maxIncomingTopicAliases == other.maxIncomingTopicAliases;
+           && this->maxIncomingTopicAliases == other.maxIncomingTopicAliases && this->tcpNoDelay == other.tcpNoDelay;
 }
 
 bool BridgeConfig::operator !=(const BridgeConfig &other) const

--- a/bridgeconfig.h
+++ b/bridgeconfig.h
@@ -58,6 +58,7 @@ public:
     std::vector<BridgeTopicPath> publishes;
     std::weak_ptr<ThreadData> owner;
     bool queueForDelete = false;
+    bool tcpNoDelay = false;
 
     void setClientId(const std::string &prefix, const std::string &id);
     const std::string &getClientid() const;

--- a/client.cpp
+++ b/client.cpp
@@ -159,6 +159,13 @@ void Client::connectToBridgeTarget(FMQSockaddr_in6 addr)
 
     this->outgoingConnection = true;
 
+
+    if (bridge->c.tcpNoDelay)
+    {
+        int tcp_nodelay_optval = 1;
+        check<std::runtime_error>(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay_optval, sizeof(tcp_nodelay_optval)));
+    }
+
     addr.setPort(bridge->c.port);
     int rc = connect(fd, addr.getSockaddr(), addr.getSize());
 
@@ -171,12 +178,6 @@ void Client::connectToBridgeTarget(FMQSockaddr_in6 addr)
     assert(rc == 0);
 
     setBridgeConnected();
-
-    if (bridge->c.tcpNoDelay)
-    {
-        int tcp_nodelay_optval = 1;
-        check<std::runtime_error>(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay_optval, sizeof(tcp_nodelay_optval)));
-    }
 }
 
 void Client::startOrContinueSslHandshake()

--- a/client.cpp
+++ b/client.cpp
@@ -15,6 +15,7 @@ See LICENSE for license details.
 #include <iostream>
 #include <cassert>
 #include <chrono>
+#include <netinet/tcp.h>
 
 #include "logger.h"
 #include "utils.h"
@@ -167,10 +168,14 @@ void Client::connectToBridgeTarget(FMQSockaddr_in6 addr)
            logger->logf(LOG_ERR, "Client connect error: %s", strerror(errno));
         return;
     }
+    assert(rc == 0);
 
-    if (rc == 0)
+    setBridgeConnected();
+
+    if (bridge->c.tcpNoDelay)
     {
-        setBridgeConnected();
+        int tcp_nodelay_optval = 1;
+        check<std::runtime_error>(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay_optval, sizeof(tcp_nodelay_optval)));
     }
 }
 

--- a/configfileparser.cpp
+++ b/configfileparser.cpp
@@ -232,6 +232,7 @@ ConfigFileParser::ConfigFileParser(const std::string &path) :
     validListenKeys.insert("client_verification_ca_dir");
     validListenKeys.insert("client_verification_still_do_authn");
     validListenKeys.insert("allow_anonymous");
+    validListenKeys.insert("tcp_nodelay");
 
     validBridgeKeys.insert("local_username");
     validBridgeKeys.insert("remote_username");
@@ -514,6 +515,11 @@ void ConfigFileParser::loadFile(bool test)
                 {
                     bool val = stringTruthiness(value);
                     curListener->allowAnonymous = val ? AllowListenerAnonymous::Yes : AllowListenerAnonymous::No;
+                }
+                if (testKeyValidity(key, "tcp_nodelay", validListenKeys))
+                {
+                    bool val = stringTruthiness(value);
+                    curListener->tcpNoDelay = val;
                 }
 
                 testCorrectNumberOfValues(key, number_of_expected_values, matches);

--- a/configfileparser.cpp
+++ b/configfileparser.cpp
@@ -257,6 +257,7 @@ ConfigFileParser::ConfigFileParser(const std::string &path) :
     validBridgeKeys.insert("keepalive");
     validBridgeKeys.insert("max_outgoing_topic_aliases");
     validBridgeKeys.insert("max_incoming_topic_aliases");
+    validBridgeKeys.insert("tcp_nodelay");
 }
 
 std::list<std::string> ConfigFileParser::readFileRecursively(const std::string &path) const
@@ -725,6 +726,10 @@ void ConfigFileParser::loadFile(bool test)
                 if (testKeyValidity(key, "remote_retain_available", validBridgeKeys))
                 {
                     curBridge->remoteRetainAvailable = stringTruthiness(value);
+                }
+                if (testKeyValidity(key, "tcp_nodelay", validBridgeKeys))
+                {
+                    curBridge->tcpNoDelay = true;
                 }
 
                 testCorrectNumberOfValues(key, number_of_expected_values, matches);

--- a/listener.cpp
+++ b/listener.cpp
@@ -58,6 +58,11 @@ bool Listener::isSsl() const
     return (!sslFullchain.empty() || !sslPrivkey.empty());
 }
 
+bool Listener::isTcpNoDelay() const
+{
+    return this->tcpNoDelay;
+}
+
 bool Listener::isHaProxy() const
 {
     return this->haproxy;

--- a/listener.h
+++ b/listener.h
@@ -31,6 +31,7 @@ struct Listener
     std::string inet6BindAddress;
     int port = 0;
     bool websocket = false;
+    bool tcpNoDelay = false;
     bool haproxy = false;
     std::string sslFullchain;
     std::string sslPrivkey;
@@ -43,6 +44,7 @@ struct Listener
     void isValid();
     bool isSsl() const;
     bool isHaProxy() const;
+    bool isTcpNoDelay() const;
     std::string getProtocolName() const;
     void loadCertAndKeyFromConfig();
     X509ClientVerification getX509ClientVerficationMode() const;

--- a/mainapp.cpp
+++ b/mainapp.cpp
@@ -18,6 +18,7 @@ See LICENSE for license details.
 #include <arpa/inet.h>
 #include <memory>
 #include <malloc.h>
+#include <netinet/tcp.h>
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -196,6 +197,12 @@ std::list<ScopedSocket> MainApp::createListenSocket(const std::shared_ptr<Listen
             // Not needed for now. Maybe I will make multiple accept threads later, with SO_REUSEPORT.
             int optval = 1;
             check<std::runtime_error>(setsockopt(uniqueListenFd.get(), SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &optval, sizeof(optval)));
+
+            if (listener->isTcpNoDelay())
+            {
+                int tcp_nodelay_optval = 1;
+                check<std::runtime_error>(setsockopt(uniqueListenFd.get(), IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay_optval, sizeof(tcp_nodelay_optval)));
+            }
 
             int flags = fcntl(uniqueListenFd.get(), F_GETFL);
             check<std::runtime_error>(fcntl(uniqueListenFd.get(), F_SETFL, flags | O_NONBLOCK ));

--- a/man/flashmq.conf.5
+++ b/man/flashmq.conf.5
@@ -18,7 +18,9 @@ To set a parameter, its name must appear on a single line, followed by whitespac
 .PP
 When setting boolean values, \*(T<yes/no\*(T>, \*(T<true/false\*(T> and \*(T<on/off\*(T> can all be used.
 .PP
-To configure the listeners, use \*(T<\fBlisten\fR\*(T> blocks, defined by { and }. See EXAMPLE LISTENERS for details.
+To configure the listeners, use \*(T<\fBlisten\fR\*(T> blocks, defined by \*(T<{\*(T> and \*(T<}\*(T>. See 
+.URL #example_listeners "EXAMPLE LISTENERS"
+for details.
 .PP
 Lines beginning with the hash character (\(lq\*(T<#\*(T>\(rq) and empty lines are ignored. Thus, a line can be commented out by prepending a \(lq\*(T<#\*(T>\(rq to it.
 .SH "GLOBAL PARAMETERS"

--- a/man/flashmq.conf.5
+++ b/man/flashmq.conf.5
@@ -5,7 +5,7 @@
 \\$2 \(la\\$1\(ra\\$3
 ..
 .if \n(.g .mso www.tmac
-.TH flashmq.conf 5 "4 May 2024" "" ""
+.TH flashmq.conf 5 "6 May 2024" "" ""
 .SH NAME
 flashmq.conf \- FlashMQ configuration file format
 .SH SYNOPSIS
@@ -539,6 +539,15 @@ Default: \*(T<0\*(T>
 If you want to accept topic aliases for this bridge, set this to a non-zero value. The value is set in the CONNECT packet to inform the remote side of the wish. It's not guaranteed that the other side will actually make aliases.
 
 Default: \*(T<0\*(T>
+.TP 
+\*(T<\fBtcp_nodelay\fR\*(T> \fItrue/false\fR 
+Default: \fIfalse\fR
+
+\*(T<\fBtcp_nodelay\fR\*(T> will cause the \*(T<TCP_NODELAY\*(T> option to be set for the client socket that is used to connect to the other end of the bridge.
+
+See the documentation for the 
+.URL #tcp_nodelay tcp_nodelay
+\fIlistener\fR parameter for further elaboration.
 .SH "EXAMPLE BRIDGE"
 .nf
 bridge {

--- a/man/flashmq.conf.5
+++ b/man/flashmq.conf.5
@@ -5,7 +5,7 @@
 \\$2 \(la\\$1\(ra\\$3
 ..
 .if \n(.g .mso www.tmac
-.TH flashmq.conf 5 "3 May 2024" "" ""
+.TH flashmq.conf 5 "4 May 2024" "" ""
 .SH NAME
 flashmq.conf \- FlashMQ configuration file format
 .SH SYNOPSIS
@@ -357,6 +357,15 @@ As a side note about using a proxy on your listener; you can only have an absolu
 See 
 .URL http://www.haproxy.org/ haproxy.org
 \&.
+.TP 
+\*(T<\fBtcp_nodelay\fR\*(T> \fItrue/false\fR 
+Default: \fIfalse\fR
+
+\*(T<\fBtcp_nodelay\fR\*(T> will cause the \*(T<TCP_NODELAY\*(T> option to be set for the listener's socket(s).
+
+\*(T<TCP_NODELAY\*(T> is a OS TCP-layer option that will cause messages written by FlashMQ to the socket to be flushed immediately, without letting Nagle's algorithm (the default) collect small outgoing TCP packets into bigger packets.
+
+Foregoing Nagle's algorithm by setting \*(T<\fBtcp_nodelay\fR\*(T> to \fItrue\fR\ \fImay\fR decrease latency, at the likely cost of some network efficiency.
 .SH "EXAMPLE LISTENERS"
 .nf
 listen {

--- a/man/flashmq.conf.5
+++ b/man/flashmq.conf.5
@@ -361,7 +361,7 @@ See
 \*(T<\fBtcp_nodelay\fR\*(T> \fItrue/false\fR 
 Default: \fIfalse\fR
 
-\*(T<\fBtcp_nodelay\fR\*(T> will cause the \*(T<TCP_NODELAY\*(T> option to be set for the listener's socket(s).
+\*(T<\fBtcp_nodelay\fR\*(T> will cause the \*(T<TCP_NODELAY\*(T> option to be set for the listener's socket(s), and therefore for all clients accepted on that listener.
 
 \*(T<TCP_NODELAY\*(T> is a OS TCP-layer option that will cause messages written by FlashMQ to the socket to be flushed immediately, without letting Nagle's algorithm (the default) collect small outgoing TCP packets into bigger packets.
 

--- a/man/flashmq.conf.5.dbk5
+++ b/man/flashmq.conf.5.dbk5
@@ -746,7 +746,7 @@
             Default: <replaceable>false</replaceable>
           </para>
           <para>
-            <option>tcp_nodelay</option> will cause the <literal>TCP_NODELAY</literal> option to be set for the listener's socket(s).
+            <option>tcp_nodelay</option> will cause the <literal>TCP_NODELAY</literal> option to be set for the listener's socket(s), and therefore for all clients accepted on that listener.
           </para>
           <para>
             <literal>TCP_NODELAY</literal> is a OS TCP-layer option that will cause messages written by FlashMQ to the socket to be flushed immediately, without letting Nagle's algorithm (the default) collect small outgoing TCP packets into bigger packets.

--- a/man/flashmq.conf.5.dbk5
+++ b/man/flashmq.conf.5.dbk5
@@ -1094,6 +1094,21 @@ listen {
         </listitem>
       </varlistentry>
 
+      <varlistentry xml:id="bridge__tcp_nodelay">
+        <term><option>tcp_nodelay</option> <replaceable>true/false</replaceable></term>
+        <listitem>
+          <para>
+            Default: <replaceable>false</replaceable>
+          </para>
+          <para>
+            <option>tcp_nodelay</option> will cause the <literal>TCP_NODELAY</literal> option to be set for the client socket that is used to connect to the other end of the bridge.
+          </para>
+          <para>
+            See the documentation for the <link xlink:href="#tcp_nodelay"><option>tcp_nodelay</option></link> <emphasis>listener</emphasis> parameter for further elaboration.
+          </para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/man/flashmq.conf.5.dbk5
+++ b/man/flashmq.conf.5.dbk5
@@ -34,7 +34,7 @@
       When setting boolean values, <literal>yes/no</literal>, <literal>true/false</literal> and <literal>on/off</literal> can all be used.
     </para>
     <para>
-      To configure the listeners, use <option>listen</option> blocks, defined by { and }. See EXAMPLE LISTENERS for details.
+      To configure the listeners, use <option>listen</option> blocks, defined by <literal>{</literal> and <literal>}</literal>. See <link xlink:href="#example_listeners">EXAMPLE LISTENERS</link> for details.
     </para>
     <para>
       Lines beginning with the hash character (“<literal>#</literal>”) and empty lines are ignored. Thus, a line can be commented out by prepending a “<literal>#</literal>” to it.
@@ -759,7 +759,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 xml:id="example_config">
+  <refsect1 xml:id="example_listeners">
     <title>Example listeners</title>
 
     <literallayout class="monospaced"><![CDATA[listen {

--- a/man/flashmq.conf.5.dbk5
+++ b/man/flashmq.conf.5.dbk5
@@ -738,6 +738,24 @@
           </para>
         </listitem>
       </varlistentry>
+
+      <varlistentry xml:id="tcp_nodelay">
+        <term><option>tcp_nodelay</option> <replaceable>true/false</replaceable></term>
+        <listitem>
+          <para>
+            Default: <replaceable>false</replaceable>
+          </para>
+          <para>
+            <option>tcp_nodelay</option> will cause the <literal>TCP_NODELAY</literal> option to be set for the listener's socket(s).
+          </para>
+          <para>
+            <literal>TCP_NODELAY</literal> is a OS TCP-layer option that will cause messages written by FlashMQ to the socket to be flushed immediately, without letting Nagle's algorithm (the default) collect small outgoing TCP packets into bigger packets.
+          </para>
+          <para>
+            Foregoing Nagle's algorithm by setting <option>tcp_nodelay</option> to <replaceable>true</replaceable>&#xa0;<emphasis>may</emphasis> decrease latency, at the likely cost of some network efficiency.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/man/flashmq.conf.5.html
+++ b/man/flashmq.conf.5.html
@@ -791,6 +791,24 @@
           </p>
         </dd>
       
+
+      
+        <dt id="tcp_nodelay"><code class="option">tcp_nodelay</code> <code class="replaceable">true/false</code><a class="hash-anchor" href="#tcp_nodelay">#</a></dt>
+        <dd>
+          <p>
+            Default: <code class="replaceable">false</code>
+          </p>
+          <p>
+            <code class="option">tcp_nodelay</code> will cause the <code class="literal">TCP_NODELAY</code> option to be set for the listener's socket(s).
+          </p>
+          <p>
+            <code class="literal">TCP_NODELAY</code> is a OS TCP-layer option that will cause messages written by FlashMQ to the socket to be flushed immediately, without letting Nagle's algorithm (the default) collect small outgoing TCP packets into bigger packets.
+          </p>
+          <p>
+            Foregoing Nagle's algorithm by setting <code class="option">tcp_nodelay</code> to <code class="replaceable">true</code> <em>may</em> decrease latency, at the likely cost of some network efficiency.
+          </p>
+        </dd>
+      
     </dl>
   </section><section class="refsect1" id="example_config">
     <header><h2>Example listeners<a class="hash-anchor" href="#example_config">#</a></h2></header>

--- a/man/flashmq.conf.5.html
+++ b/man/flashmq.conf.5.html
@@ -91,7 +91,7 @@
       When setting boolean values, <code class="literal">yes/no</code>, <code class="literal">true/false</code> and <code class="literal">on/off</code> can all be used.
     </p>
     <p>
-      To configure the listeners, use <code class="option">listen</code> blocks, defined by { and }. See EXAMPLE LISTENERS for details.
+      To configure the listeners, use <code class="option">listen</code> blocks, defined by <code class="literal">{</code> and <code class="literal">}</code>. See <a href="#example_listeners">EXAMPLE LISTENERS</a> for details.
     </p>
     <p>
       Lines beginning with the hash character (“<code class="literal">#</code>”) and empty lines are ignored. Thus, a line can be commented out by prepending a “<code class="literal">#</code>” to it.
@@ -810,8 +810,8 @@
         </dd>
       
     </dl>
-  </section><section class="refsect1" id="example_config">
-    <header><h2>Example listeners<a class="hash-anchor" href="#example_config">#</a></h2></header>
+  </section><section class="refsect1" id="example_listeners">
+    <header><h2>Example listeners<a class="hash-anchor" href="#example_listeners">#</a></h2></header>
 
     <pre class="literallayout monospaced">listen {
   protocol mqtt

--- a/man/flashmq.conf.5.html
+++ b/man/flashmq.conf.5.html
@@ -1143,6 +1143,21 @@ listen {
         </dd>
       
 
+      
+        <dt id="bridge__tcp_nodelay"><code class="option">tcp_nodelay</code> <code class="replaceable">true/false</code><a class="hash-anchor" href="#bridge__tcp_nodelay">#</a></dt>
+        <dd>
+          <p>
+            Default: <code class="replaceable">false</code>
+          </p>
+          <p>
+            <code class="option">tcp_nodelay</code> will cause the <code class="literal">TCP_NODELAY</code> option to be set for the client socket that is used to connect to the other end of the bridge.
+          </p>
+          <p>
+            See the documentation for the <a href="#tcp_nodelay"><code class="option">tcp_nodelay</code></a> <em>listener</em> parameter for further elaboration.
+          </p>
+        </dd>
+      
+
     </dl>
   </section><section class="refsect1" id="example_bridge">
     <header><h2>Example bridge<a class="hash-anchor" href="#example_bridge">#</a></h2></header>

--- a/man/flashmq.conf.5.html
+++ b/man/flashmq.conf.5.html
@@ -799,7 +799,7 @@
             Default: <code class="replaceable">false</code>
           </p>
           <p>
-            <code class="option">tcp_nodelay</code> will cause the <code class="literal">TCP_NODELAY</code> option to be set for the listener's socket(s).
+            <code class="option">tcp_nodelay</code> will cause the <code class="literal">TCP_NODELAY</code> option to be set for the listener's socket(s), and therefore for all clients accepted on that listener.
           </p>
           <p>
             <code class="literal">TCP_NODELAY</code> is a OS TCP-layer option that will cause messages written by FlashMQ to the socket to be flushed immediately, without letting Nagle's algorithm (the default) collect small outgoing TCP packets into bigger packets.


### PR DESCRIPTION
How I came to the idea for this new option was when I learned that `curl`, since version 7.50.2, sets `TCP_NODELAY` by default.

`TCP_NODELAY` _may_ decrease latency and may thus be worthwhile to be able to experiment with in some scenarios, to try if its benefits don't outweigh its main tradeoff (i.e., more, smaller TCP messages).

The reason that I added this as a boolean setting is that, as far as I can tell, there are only three modes to choose from, and I guessed that Wiebe is not interested in using `TCP_CORK` in the future:

1. The default is that the TCP layer uses Nagle's algorithm to collect what would become multiple, small TCP packets into a larger packet until acknowledgement has been received for the last sent message.
2. `TCP_NODELAY` sends out TCP packets immediately, possible reducing latency, but at the likely cost of efficiency.
3. `TCP_CORK` does such buffering explicitly, waiting for `setsockoption()` from the application to flush the buffer.

If I am wrong and there _is_ a potential future use for `TCP_CORK`, this option should probably be changed into an enum.

I have done a superficial test of this new feature using `mosquitto_sub` and `mosquitto_pub`, only to the extent to check if a listener with `tcp_nodelay true` still functions.  What I did not do is to trace what actually happens on the TCP level.

I do not whether and where this needs to be added to the automated test suite.