### PR TITLE
Fix hardcoded paths in testcases

### DIFF
--- a/FlashMQTests/flashmqtempdir.cpp
+++ b/FlashMQTests/flashmqtempdir.cpp
@@ -2,12 +2,13 @@
 
 #include <sys/types.h>
 #include <unistd.h>
+#include <filesystem>
 
 #include "utils.h"
 
 FlashMQTempDir::FlashMQTempDir()
 {
-    const std::string templateName("/tmp/flashmq_storage_test_XXXXXX");
+    const std::string templateName(std::filesystem::temp_directory_path() / "flashmq_test_XXXXXX");
     std::vector<char> nameBuf(templateName.size() + 1, 0);
     std::copy(templateName.begin(), templateName.end(), nameBuf.begin());
     this->path = std::string(mkdtemp(nameBuf.data()));
@@ -15,7 +16,7 @@ FlashMQTempDir::FlashMQTempDir()
 
 FlashMQTempDir::~FlashMQTempDir()
 {
-    if (this->path.empty() || !strContains(this->path, "flashmq_storage_test"))
+    if (this->path.empty() || !strContains(this->path, "flashmq_test_"))
         return;
 
     // Not pretty, but whatever works...
@@ -26,7 +27,7 @@ FlashMQTempDir::~FlashMQTempDir()
     }
 }
 
-const std::string &FlashMQTempDir::getPath() const
+const std::filesystem::path &FlashMQTempDir::getPath() const
 {
     return this->path;
 }

--- a/FlashMQTests/flashmqtempdir.h
+++ b/FlashMQTests/flashmqtempdir.h
@@ -1,18 +1,19 @@
 #ifndef FLASHMQTEMPDIR_H
 #define FLASHMQTEMPDIR_H
 
+#include <filesystem>
 #include <stdlib.h>
 #include <string>
 #include <vector>
 
 class FlashMQTempDir
 {
-    std::string path;
+    std::filesystem::path path;
 
 public:
     FlashMQTempDir();
     ~FlashMQTempDir();
-    const std::string &getPath() const;
+    const std::filesystem::path &getPath() const;
 };
 
 #endif // FLASHMQTEMPDIR_H


### PR DESCRIPTION
I share my tmpdir with Portage that runs testcases with its own user account. If there are hardcoded paths I run into permissions issues when I want to run the testcases myself.

I took the liberty to slightly change the FlashMQTempDir: I had built the same thing already before I saw this one existed and lifted some implementation details I liked from my code (all C++17 valid).