### PR TITLE
Show all frames and their local variables on assert failures [WIP]

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,4 +26,7 @@ jobs:
       - run: sudo apt install -y cmake libssl-dev libcurl4-openssl-dev ${{ matrix.aptpkg }}
       # Building
       - run: ./run-make-from-ci.sh --compiler "${{ matrix.compiler }}"
+      # Test prerequisites
+      - run: sudo apt install -y gdb
+      # Testing
       - run: ./run-tests-from-ci.sh

--- a/.github/workflows/testing_non_sse.yml
+++ b/.github/workflows/testing_non_sse.yml
@@ -26,4 +26,7 @@ jobs:
       - run: sudo apt install -y cmake libssl-dev libcurl4-openssl-dev ${{ matrix.aptpkg }}
       # Building
       - run: ./run-make-from-ci.sh --compiler "${{ matrix.compiler }}" --extra-config "FMQ_NO_SSE=1"
+      # Test prerequisites
+      - run: sudo apt install -y gdb
+      # Testing
       - run: ./run-tests-from-ci.sh

--- a/FlashMQTests/run-make-from-ci.sh
+++ b/FlashMQTests/run-make-from-ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-extra_configs=()
+extra_configs=("CMAKE_BUILD_TYPE=Debug")
 compiler="g++"
 
 while [ -n "$*" ]; do

--- a/FlashMQTests/run-tests-from-ci.sh
+++ b/FlashMQTests/run-tests-from-ci.sh
@@ -4,7 +4,7 @@ STDERR_LOG=$(mktemp)
 
 cd buildtests || exit 1
 
-if ./flashmq-tests 2> "$STDERR_LOG" ; then
+if gdb --batch -x ../show-frames-on-hook.pdb.py --args ./flashmq-tests 2> "$STDERR_LOG" ; then
   echo -e '\033[01;32mSUCCESS!\033[00m'
 else
   echo -e '\033[01;31mBummer\033[00m'

--- a/FlashMQTests/show-frames-on-hook.pdb.py
+++ b/FlashMQTests/show-frames-on-hook.pdb.py
@@ -1,0 +1,57 @@
+# NB: the gdb object is given to us by gdb, we don't need to import it
+
+# Making gdb a bit quieter
+gdb.execute("set print thread-events off")
+gdb.execute("set print inferior-events off")
+
+# since our class runs in a separate thread and has different variables we'll
+# need to store $issues inside GDB itself
+gdb.execute("set $issues = 0")
+
+class ShowFrames(gdb.Breakpoint):
+    def stop(self):
+        # Are in in[MainTests::testAsserts]? If yes don't do anything (this is testing the framework on bootup)
+        frame = gdb.selected_frame()
+        while frame:
+            # The name is a bit compiler dependent, I've seen:
+            # MainTests::testAsserts
+            # MainTests::testAsserts()
+            if frame.name().startswith("MainTests::testAsserts"):
+                return False
+            frame = frame.older()
+
+        # This is a real assert triggering
+        gdb.execute("set $issues += 1")
+
+        frame = gdb.selected_frame()
+
+        indentation = ""
+        while frame:
+            print(f"{indentation}- [{frame.name()}]")
+            indentation += "  "
+
+            try:
+                block = frame.block()
+            except:
+                #  doc: If the frame does not have a block – for example, if there is no debugging information for the code in question – then this will throw an exception.
+                pass
+            else:
+                for variable in block:
+                    print(f"{indentation}{variable.print_name} = ", end='')
+                    if variable.print_name in ['maintests']:
+                        print("(skipped)")
+                    else:
+                        try:
+                            print(f"{variable.value(frame)} ({variable.type})")
+                        except Exception as e:
+                            print(f"({e})")
+            if frame.name().startswith('MainTests::'):
+                # if we go further up we'll end up in test runner's code, not too interesting
+                break
+            frame = frame.older()
+
+        return False
+
+ShowFrames("trigger_gdb_if_attached")
+gdb.execute("run")
+gdb.execute("quit $issues")

--- a/FlashMQTests/testhelpers.cpp
+++ b/FlashMQTests/testhelpers.cpp
@@ -7,12 +7,20 @@ int assert_count;
 int assert_fail_count;
 bool asserts_print;
 
+void trigger_gdb_if_attached()
+{
+    // separate function to make it easier to hook into from gdb.
+    // if you don't have gdb attached this is a noop.
+}
+
 bool fmq_assert(bool b, const char *failmsg, const char *actual, const char *expected, const char *file, int line)
 {
     assert_count++;
 
     if (!b)
     {
+        trigger_gdb_if_attached();
+
         assert_fail_count++;
 
         if (asserts_print)


### PR DESCRIPTION
* Feel free to close this PR if you're not interested: I made it for fun while playing around with `gdb`, just to see what's possible.
* The WIP part: I only hooked it into one of the assert failures, I think you have a few other roads how testcases could fail. I have no desire to polish this further, take it or leave it 😃 

This is a separate implementation but the same idea as #129. I initially tried the other approach, ran into issues, pivoted to this solution, and once it was done I realized how I could achieve my original idea.

This implementation is cleaner but also less useful: instead of providing you with coredumps it will only show similar stack info on the terminal. It is more flexible for customization though: right now it only prints the frame name + local variables but you can show whatever you want.

---

This PR will show you stack information when an assertion failure is triggered. An example output:

```
INIT: testStringDistances
RUN: testStringDistances
- [trigger_gdb_if_attached]
  - [fmq_assert]
    b = false (bool)
    failmsg = 0x55555594ddf2 "Values aren't the same" (const char *)
    actual = 0x5555559511c8 "distanceBetweenStrings(\"\", \"whoopsie\")" (const char *)
    expected = 0x5555559511b8 "(unsigned int)0" (const char *)
    file = 0x555555950fd8 "/home/quinox/projects/FlashMQ/FlashMQTests/configtests.cpp" (const char *)
    line = 123 (int)
    - [fmq_compare<unsigned int, unsigned int>]
      t1 = @0x7fffffffdd58 (const unsigned int &)
      t2 = @0x7fffffffdd5c (const unsigned int &)
      actual = 0x5555559511c8 "distanceBetweenStrings(\"\", \"whoopsie\")" (const char *)
      expected = 0x5555559511b8 "(unsigned int)0" (const char *)
      file = 0x555555950fd8 "/home/quinox/projects/FlashMQ/FlashMQTests/configtests.cpp" (const char *)
      line = 123 (int)
      - [MainTests::testStringDistances]
        this = 0x7fffffffe120 (MainTests * const)
FAIL: 'Values aren't the same', distanceBetweenStrings("", "whoopsie") != (unsigned int)0
 in /home/quinox/projects/FlashMQ/FlashMQTests/configtests.cpp, line 123
FAIL: testStringDistances

Tests run: 1. Passed: 0. Failed: 1 (of which 0 exceptions). Total assertions: 1.


Failed tests:
 - testStringDistances

TESTS FAILED
[Inferior 1 (process 13425) exited with code 01]
Bummer


Tail of stderr:
```
